### PR TITLE
Add artefact banner below hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,6 +411,22 @@
             font-weight: 500;
         }
 
+        .artefact-banner {
+            background: #ed811c;
+            padding: 3rem 2rem;
+            text-align: center;
+            margin-top: 2rem;
+        }
+
+        .artefact-banner h2 {
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .artefact-banner p {
+            margin-bottom: 0;
+        }
+
         @media (max-width: 768px) {
             .bottom-banner {
                 flex-direction: column;
@@ -443,6 +459,10 @@
         </div>
     </section>
 
+    <div class="artefact-banner">
+        <h2>Artefacts</h2>
+        <p>Think of these as checkpoints on the map of human experience, the things AI needs to master just to be marginally interesting</p>
+    </div>
 
     <section class="timeline-container" id="timeline">
         <svg class="pathway-svg" id="pathwaySvg">


### PR DESCRIPTION
## Summary
- introduce `.artefact-banner` style for new orange bar
- insert new bar after the hero banner with heading and caption

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f241361a4832493a41f415357859d