### PR TITLE
Add headings for interactive section

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,6 +609,7 @@
         #interactive-section .half {
             flex: 1;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
             padding: 2rem;
@@ -617,6 +618,13 @@
         #interactive-section .cards-half {
             background: #ed1c24;
             color: #fff;
+        }
+        .interactive-title {
+            font-size: 2rem;
+            margin-bottom: 1.5rem;
+            font-weight: 500;
+            text-align: center;
+            width: 100%;
         }
         .card-stack {
             display: flex;
@@ -783,6 +791,7 @@
 
 <section id="interactive-section">
   <div class="half cards-half">
+    <h2 class="interactive-title">2-minute Reads</h2>
     <div class="card-stack">
       <div class="card">Card 1</div>
       <div class="card">Card 2</div>
@@ -790,6 +799,7 @@
     </div>
   </div>
   <div class="half">
+    <h2 class="interactive-title">Industry Predictions &amp; Factcheck</h2>
     <ul class="vertical-timeline">
       <li><a href="#">Milestone 1</a></li>
       <li><a href="#">Milestone 2</a></li>


### PR DESCRIPTION
## Summary
- add headings for posts and timeline in the interactive split section
- update layout to stack new headings neatly
- style the new headings with `.interactive-title`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874863c1ca48324a37b06b8daf75046