### PR TITLE
Fix card labels and timeline style

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,8 +611,11 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
+            justify-content: flex-start;
             padding: 2rem;
+        }
+        #interactive-section .timeline-half {
+            background: #EAEBD0;
         }
         /* left side with cards */
         #interactive-section .cards-half {
@@ -811,12 +814,12 @@
   <div class="half cards-half">
     <h2 class="interactive-title">2-minute Reads</h2>
     <div class="card-stack">
-      <div class="card">Card 1</div>
-      <div class="card">Card 2</div>
-      <div class="card">Card 3</div>
+      <div class="card">Post 1</div>
+      <div class="card">Post 2</div>
+      <div class="card">Post 3</div>
     </div>
   </div>
-  <div class="half">
+  <div class="half timeline-half">
     <h2 class="interactive-title">Industry Predictions &amp; Factcheck</h2>
     <div class="timeline-scroll">
       <ul class="vertical-timeline timeline-inner">


### PR DESCRIPTION
## Summary
- label cards as Post 1-3
- add styling for timeline half
- align interactive section titles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874a217682c8324aab537f73d41a168