### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -81,6 +81,22 @@
             opacity: 0.7;
             margin-top: 0.5rem;
         }
+
+        @media (max-width: 600px) {
+            .topbar {
+                flex-direction: column;
+            }
+
+            .back-link {
+                margin-left: 0;
+                margin-top: 0.5rem;
+            }
+
+            .container {
+                grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+                grid-auto-rows: 150px;
+            }
+        }
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -782,6 +782,48 @@
         .vertical-timeline .past::before { background: #6c757d; }
         .vertical-timeline .current::before { background: #ffc107; }
         .vertical-timeline .future::before { background: #28a745; }
+
+        /* Extra mobile tweaks */
+        @media (max-width: 600px) {
+            .topbar {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .topbar .menu {
+                flex-wrap: wrap;
+                width: 100%;
+                justify-content: center;
+                margin-top: 0.5rem;
+            }
+
+            .banner {
+                padding: 0 2rem;
+            }
+
+            .banner-content {
+                flex-direction: column;
+                text-align: center;
+            }
+
+            .banner-right {
+                margin-top: 1rem;
+            }
+
+            .about-section {
+                height: auto;
+                padding: 2rem 4%;
+            }
+
+            #interactive-section {
+                flex-direction: column;
+                height: auto;
+            }
+
+            #interactive-section .half {
+                width: 100%;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add mobile-friendly layout for the top bar, banner, about section and interactive timeline
- tweak artefact page layout for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883d4bc9e9c8324be4a8ce831c50965