### PR TITLE
Add third 2-minute read card on AGI expectations

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,7 +882,7 @@
     <div class="card-stack">
       <div class="card glass-block" data-content="post1-template">Does Your Problem Really Need AI?</div>
       <div class="card glass-block" data-content="post2-template">Are LLMs Really Creative? Breaking Down the Myth</div>
-      <div class="card glass-block">Post 3 (Coming Soon)</div>
+      <div class="card glass-block" data-content="post3-template">GPT-5 is not AGI. Here is why GPT-6 will not be either</div>
     </div>
   </div>
   <div class="half timeline-half">
@@ -1089,6 +1089,43 @@
   <p>Creativity = Diversity × Relevance</p>
   <p>Despite these mathematical attempts, creativity is about much more than novelty, usefulness, or even surprise. It is deeply tied to context, intention, and cultural meaning, things that are notoriously hard to measure or define. Large language models (LLMs) do not have a true understanding of what they are generating, and they are always limited by their training data. Most importantly, LLMs lack intent or purpose. They do not want to create; they simply predict the next word or token based on patterns in the data.</p>
   <p>In the end, a lot of what makes something genuinely creative cannot be measured with any current formula. Until we can identify all the hidden ingredients that go into creativity and find reliable ways to measure them, creativity will remain a distinctly human quality, one that is still out of reach for even the most advanced AI.</p>
+</template>
+
+<template id="post3-template">
+  <h1>GPT-5 is not AGI. Here is why GPT-6 will not be either</h1>
+  <p>When GPT-5 was nearing release, the buzz made it seem like AGI was just around the corner. What we actually got was better speed, slightly improved accuracy, stronger reasoning, and tighter safety. Useful, yes. A quantum leap, no.</p>
+  <h2>Why this cycle repeats</h2>
+  <ul>
+    <li>There is no single, industry-wide definition of AGI.</li>
+    <li>Without a shared finish line, every big release invites a fresh round of "maybe this is it."</li>
+    <li>Incentives reward attention and headlines, so hype keeps compounding.</li>
+  </ul>
+  <h2>Common AGI definitions people cite</h2>
+  <ul>
+    <li><strong>Economically useful work at human level or better.</strong> A system that can perform most economically valuable tasks at least as well as a typical human.</li>
+    <li><strong>General problem-solving across many domains.</strong> The capacity to achieve goals in a wide range of environments, not just a single narrow task.</li>
+    <li><strong>Human-level cognition.</strong> A system that is broadly indistinguishable from a human across most cognitive activities in everyday life.</li>
+  </ul>
+  <p>These are all reasonable, yet they point in slightly different directions. Measure AGI by jobs and you get one yardstick. Measure it by goal-achievement across environments and you get another. Tie it to human likeness and you get a third. No wonder timelines swing wildly.</p>
+  <h2>Intelligence keeps evolving</h2>
+  <p>Intelligence is not a fixed target. It shifts with tools, context, and coordination. Calculators changed what "mental math" meant. The web changed what "knowledge at your fingertips" meant. Today, AI agents with tools, memory, and retrieval reshape what "being smart" looks like in practice. As our environments change, the bar for intelligence moves with them. This is why "AGI" will keep being debated, even when capabilities rise.</p>
+  <h2>Practical bottlenecks still matter</h2>
+  <ul>
+    <li>Continual learning</li>
+    <li>Feedback efficiency</li>
+    <li>Catastrophic forgetting</li>
+    <li>Data dependency</li>
+    <li>Robustness, calibration, and verifiability in messy, real-world workflows</li>
+  </ul>
+  <p>These are not headline-friendly, yet they decide whether a system can stay reliable in production, quarter after quarter.</p>
+  <h2>What actually shipped vs. what was hyped</h2>
+  <ul>
+    <li><strong>Shipped:</strong> faster inference, better accuracy, improved reasoning on standard tasks, stronger safety and controls.</li>
+    <li><strong>Hyped:</strong> end-to-end autonomy, plug-and-play replacements for whole teams, instant productization without integration or process change.</li>
+  </ul>
+  <h2>Where to focus next</h2>
+  <p>Benchmarks, leaderboards, and contest prizes are useful signals, but they are not the destination. The real win is deploying systems that deliver durable value in production: lower cost per task, higher throughput, fewer errors, simpler workflows, happier users.</p>
+  <p>Irrespective of benchmark scores and contest prizes, we must focus on making these systems economically useful at scale. Then chase AGI.</p>
 </template>
 
 


### PR DESCRIPTION
## Summary
- Add third 2-minute read card linking to new article on GPT-5 and GPT-6 not being AGI
- Provide full article template with bullet points on AGI definitions, evolving intelligence, bottlenecks, and practical focus

## Testing
- `tidy -q -e index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c062fc3548324a8b5c81e1c89efab