### PR TITLE
Add turquoise card styling with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,12 +675,12 @@
             content: "";
             position: absolute;
             inset: 0;
-            background: rgba(255,255,255,0.15);
+            background: rgba(64,224,208,0.15);
             backdrop-filter: blur(20px) saturate(180%);
             -webkit-backdrop-filter: blur(20px) saturate(180%);
             border-radius: inherit;
-            border: 1px solid rgba(255,255,255,0.3);
-            box-shadow: 0 4px 30px rgba(0,0,0,0.3), inset 0 0 15px rgba(255,255,255,0.1);
+            border: 1px solid rgba(64,224,208,0.3);
+            box-shadow: 0 4px 30px rgba(64,224,208,0.2), inset 0 0 15px rgba(64,224,208,0.1);
             opacity: 1;
             transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
             z-index: 0;
@@ -691,7 +691,7 @@
         }
         .card:hover {
             transform: scale(1.05);
-            box-shadow: 0 15px 40px rgba(255,255,255,0.3);
+            box-shadow: 0 15px 40px rgba(64,224,208,0.3);
         }
         .card-modal {
             position: fixed;
@@ -883,6 +883,9 @@
       <div class="card glass-block" data-content="post1-template">Does Your Problem Really Need AI?</div>
       <div class="card glass-block" data-content="post2-template">Are LLMs Really Creative? Breaking Down the Myth</div>
       <div class="card glass-block" data-content="post3-template">GPT-5 is not AGI. Here is why GPT-6 will not be either</div>
+      <div class="card glass-block"></div>
+      <div class="card glass-block"></div>
+      <div class="card glass-block"></div>
     </div>
   </div>
   <div class="half timeline-half">


### PR DESCRIPTION
## Summary
- switch 2-minute read card styling to turquoise
- add three empty card placeholders below existing 2-minute read cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e52ade5083249ec6f883b19cc81a