### PR TITLE
Fix card layout for 2-minute reads

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
         }
         .card-stack {
             width: 100%;
-            height: 700px;
+            height: 1000px;
             position: relative;
             perspective: 1000px;
         }
@@ -701,11 +701,11 @@
         .card:nth-child(4) {
             --rotate: 5deg;
             --tx: -240px;
-            --ty: 120px;
+            --ty: 360px;
             --tz: -20px;
             --hover-rotate: 0deg;
             --hover-tx: -400px;
-            --hover-ty: 160px;
+            --hover-ty: 400px;
             --hover-tz: 0px;
             transition-delay: 0.3s;
             background: linear-gradient(145deg, #fbc2eb, #a6c1ee);
@@ -713,11 +713,11 @@
         .card:nth-child(5) {
             --rotate: -6deg;
             --tx: -120px;
-            --ty: 180px;
+            --ty: 420px;
             --tz: -10px;
             --hover-rotate: 0deg;
             --hover-tx: -200px;
-            --hover-ty: 160px;
+            --hover-ty: 400px;
             --hover-tz: 0px;
             transition-delay: 0.4s;
             background: linear-gradient(145deg, #f6d365, #fda085);
@@ -725,11 +725,11 @@
         .card:nth-child(6) {
             --rotate: 4deg;
             --tx: -10px;
-            --ty: 200px;
+            --ty: 440px;
             --tz: 0px;
             --hover-rotate: 0deg;
             --hover-tx: 0px;
-            --hover-ty: 160px;
+            --hover-ty: 400px;
             --hover-tz: 0px;
             transition-delay: 0.5s;
             background: linear-gradient(145deg, #ffecd2, #fcb69f);
@@ -737,11 +737,11 @@
         .card:nth-child(7) {
             --rotate: -5deg;
             --tx: 120px;
-            --ty: 160px;
+            --ty: 400px;
             --tz: -10px;
             --hover-rotate: 0deg;
             --hover-tx: 200px;
-            --hover-ty: 160px;
+            --hover-ty: 400px;
             --hover-tz: 0px;
             transition-delay: 0.6s;
             background: linear-gradient(145deg, #cfd9df, #e2ebf0);
@@ -749,11 +749,11 @@
         .card:nth-child(8) {
             --rotate: 6deg;
             --tx: 240px;
-            --ty: 180px;
+            --ty: 420px;
             --tz: -20px;
             --hover-rotate: 0deg;
             --hover-tx: 400px;
-            --hover-ty: 160px;
+            --hover-ty: 400px;
             --hover-tz: 0px;
             transition-delay: 0.7s;
             background: linear-gradient(145deg, #f9f7d9, #e0c3fc);


### PR DESCRIPTION
## Summary
- Push "Coming Soon" cards into a second row within the 2-minute Reads section
- Increase stack height and adjust transforms so cards don't overlap and still animate together

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a106b8ac388324b01a37f38c41cad8