### PR TITLE
Rebuild 2-minute reads section

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,11 +594,12 @@
             width: 100%;
             background: linear-gradient(135deg, #1E293B 0%, #0F172A 100%);
             color: #fff;
-            padding: 3rem 0 6rem;
-            min-height: 700px;
+            padding: 3rem 0;
+            min-height: 80vh;
             display: flex;
             flex-direction: column;
             align-items: center;
+            justify-content: center;
             position: relative;
         }
         #reads-section .interactive-title {
@@ -623,23 +624,18 @@
 
 
         .card-stack {
+            position: relative;
             width: 100%;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            overflow-x: auto;
-            scroll-snap-type: x mandatory;
-            scroll-behavior: smooth;
-            padding: 2rem calc(50% - 150px);
-            perspective: 1000px;
-            -ms-overflow-style: none;
-            scrollbar-width: none;
-        }
-        .card-stack::-webkit-scrollbar {
-            display: none;
+            max-width: 1200px;
+            height: 420px;
+            overflow: visible;
         }
         .card {
-            flex: 0 0 260px;
+            --hover-scale: 1;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 260px;
             height: 360px;
             color: #111827;
             display: flex;
@@ -653,21 +649,25 @@
             background: linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.1));
             backdrop-filter: blur(10px);
             box-shadow: 0 15px 30px rgba(0,0,0,0.2);
-            transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-            scroll-snap-align: center;
-            overflow: visible;
+            transition: transform 0.6s ease-in-out, box-shadow 0.3s ease;
+            transform: translate(-50%, -50%) rotate(var(--angle)) translate(var(--dx), var(--dy)) scale(var(--hover-scale));
+        }
+        .card-stack:hover .card,
+        .card-stack:focus-within .card {
+            transform: translate(-50%, -50%) translateX(calc(var(--pos) * 120%)) scale(var(--hover-scale));
         }
         .card:hover {
+            --hover-scale: 1.05;
             box-shadow: 0 20px 35px rgba(0,0,0,0.3);
         }
-        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); }
-        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); }
-        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); }
-        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); }
-        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); }
-        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); }
-        .card:nth-child(7) { background: linear-gradient(145deg, #cfd9df, #e2ebf0); }
-        .card:nth-child(8) { background: linear-gradient(145deg, #f9f7d9, #e0c3fc); }
+        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); --angle: -8deg; --dx: -40px; --dy: -20px; --pos: -3.5; }
+        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); --angle: 6deg; --dx: -10px; --dy: 30px; --pos: -2.5; }
+        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); --angle: -4deg; --dx: 20px; --dy: -25px; --pos: -1.5; }
+        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); --angle: 8deg; --dx: -30px; --dy: 15px; --pos: -0.5; }
+        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); --angle: -6deg; --dx: 15px; --dy: 20px; --pos: 0.5; }
+        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); --angle: 5deg; --dx: 35px; --dy: -15px; --pos: 1.5; }
+        .card:nth-child(7) { background: linear-gradient(145deg, #cfd9df, #e2ebf0); --angle: -3deg; --dx: -25px; --dy: 25px; --pos: 2.5; }
+        .card:nth-child(8) { background: linear-gradient(145deg, #f9f7d9, #e0c3fc); --angle: 9deg; --dx: 25px; --dy: -35px; --pos: 3.5; }
 
         .card:focus {
             outline: 2px solid #111827;
@@ -681,12 +681,23 @@
                 min-height: auto;
             }
             .card-stack {
-                padding: 1rem calc(50% - 130px);
+                height: auto;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                position: static;
                 gap: 1rem;
             }
+            .card-stack:hover .card,
+            .card-stack:focus-within .card {
+                transform: scale(var(--hover-scale));
+            }
             .card {
-                flex: 0 0 80%;
-                height: 320px;
+                position: relative;
+                width: 80%;
+                max-width: 320px;
+                height: 240px;
+                transform: scale(var(--hover-scale));
             }
         }
         .card-modal {
@@ -1601,85 +1612,13 @@
 
         window.addEventListener('resize', debounce(createPathways, 250));
 
-        // Card stack interactions
+        // Card interactions
         const cardStack = document.querySelector('.card-stack');
         const modal = document.getElementById('cardModal');
-        const modalContent = modal.querySelector('.modal-content');
-        if (cardStack) {
-            const cards = Array.from(cardStack.querySelectorAll('.card'));
-
-            function updateCoverflow() {
-                const center = cardStack.scrollLeft + cardStack.clientWidth / 2;
-                const maxAngle = window.innerWidth < 600 ? 35 : 45;
-                cards.forEach(card => {
-                    const cardCenter = card.offsetLeft + card.offsetWidth / 2;
-                    const offset = (cardCenter - center) / cardStack.clientWidth;
-                    const angle = -offset * maxAngle;
-                    const scale = Math.max(0.8, 1.5 - Math.abs(offset) * 0.5);
-                    const z = -Math.abs(offset) * 150;
-                    const tx = offset * 50;
-                    const blur = Math.min(Math.abs(offset) * 1.5, 2);
-                    const brightness = 1 - Math.min(Math.abs(offset) * 0.3, 0.3);
-                    card.style.transform = `translateX(${tx}px) rotateY(${angle}deg) translateZ(${z}px) scale(${scale})`;
-                    card.style.zIndex = Math.round(1000 - Math.abs(offset) * 1000);
-                    card.style.filter = `blur(${blur}px) brightness(${brightness})`;
-                });
-            }
-
-            cardStack.addEventListener('scroll', updateCoverflow);
-
-            cardStack.addEventListener('wheel', (e) => {
-                if (cardStack.scrollWidth > cardStack.clientWidth) {
-                    e.preventDefault();
-                    cardStack.scrollLeft += e.deltaY;
-                }
-            }, { passive: false });
-
-            let isDown = false;
-            let startX = 0;
-            let scrollStart = 0;
-
-            cardStack.addEventListener('mousedown', e => {
-                isDown = true;
-                startX = e.pageX;
-                scrollStart = cardStack.scrollLeft;
-            });
-            cardStack.addEventListener('mouseleave', () => { isDown = false; });
-            cardStack.addEventListener('mouseup', () => { isDown = false; });
-            cardStack.addEventListener('mousemove', e => {
-                if (!isDown) return;
-                e.preventDefault();
-                cardStack.scrollLeft = scrollStart - (e.pageX - startX);
-            });
-
-            cardStack.addEventListener('touchstart', e => {
-                startX = e.touches[0].pageX;
-                scrollStart = cardStack.scrollLeft;
-            });
-            cardStack.addEventListener('touchmove', e => {
-                cardStack.scrollLeft = scrollStart - (e.touches[0].pageX - startX);
-            });
-
-            cardStack.addEventListener('keydown', e => {
-                if (e.key === 'ArrowRight') {
-                    cardStack.scrollBy({ left: cards[0].offsetWidth + 16, behavior: 'smooth' });
-                } else if (e.key === 'ArrowLeft') {
-                    cardStack.scrollBy({ left: -(cards[0].offsetWidth + 16), behavior: 'smooth' });
-                }
-            });
-
-            cards.forEach(card => {
-                card.addEventListener('focus', () => {
-                    card.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
-                });
-                card.addEventListener('click', (e) => {
-                    const cardCenter = card.offsetLeft + card.offsetWidth / 2;
-                    const containerCenter = cardStack.scrollLeft + cardStack.clientWidth / 2;
-                    if (Math.abs(cardCenter - containerCenter) > 5) {
-                        e.preventDefault();
-                        card.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
-                        return;
-                    }
+        const modalContent = modal ? modal.querySelector('.modal-content') : null;
+        if (cardStack && modal && modalContent) {
+            cardStack.querySelectorAll('.card').forEach(card => {
+                card.addEventListener('click', () => {
                     const tplId = card.dataset.content;
                     if (tplId) {
                         const tpl = document.getElementById(tplId);
@@ -1689,11 +1628,13 @@
                     }
                     modal.classList.add('active');
                 });
+                card.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        card.click();
+                    }
+                });
             });
-
-            window.addEventListener('resize', updateCoverflow);
-            cards[Math.floor(cards.length / 2)].scrollIntoView({ behavior: 'instant', inline: 'center', block: 'nearest' });
-            updateCoverflow();
         }
         if (modal) {
             modal.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- refactor 2-minute Reads layout into overlapped stack that fans out on hover
- add responsive vertical layout for mobile and keep 8-card set with coming soon placeholders
- simplify card click handling for modal popup

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a11e65fe2483248c68701b812eb317