### PR TITLE
Limit read cards to six and adjust stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,14 +660,12 @@
             --hover-scale: 1.05;
             box-shadow: 0 20px 35px rgba(0,0,0,0.3);
         }
-        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); --angle: -8deg; --dx: -40px; --dy: -20px; --pos: -3.5; }
-        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); --angle: 6deg; --dx: -10px; --dy: 30px; --pos: -2.5; }
-        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); --angle: -4deg; --dx: 20px; --dy: -25px; --pos: -1.5; }
-        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); --angle: 8deg; --dx: -30px; --dy: 15px; --pos: -0.5; }
-        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); --angle: -6deg; --dx: 15px; --dy: 20px; --pos: 0.5; }
-        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); --angle: 5deg; --dx: 35px; --dy: -15px; --pos: 1.5; }
-        .card:nth-child(7) { background: linear-gradient(145deg, #cfd9df, #e2ebf0); --angle: -3deg; --dx: -25px; --dy: 25px; --pos: 2.5; }
-        .card:nth-child(8) { background: linear-gradient(145deg, #f9f7d9, #e0c3fc); --angle: 9deg; --dx: 25px; --dy: -35px; --pos: 3.5; }
+        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); --angle: -8deg; --dx: -40px; --dy: -20px; --pos: -2.5; z-index: 6; }
+        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); --angle: 6deg; --dx: -10px; --dy: 30px; --pos: -1.5; z-index: 5; }
+        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); --angle: -4deg; --dx: 20px; --dy: -25px; --pos: -0.5; z-index: 4; }
+        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); --angle: 8deg; --dx: -30px; --dy: 15px; --pos: 0.5; z-index: 3; }
+        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); --angle: -6deg; --dx: 15px; --dy: 20px; --pos: 1.5; z-index: 2; }
+        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); --angle: 5deg; --dx: 35px; --dy: -15px; --pos: 2.5; z-index: 1; }
 
         .card:focus {
             outline: 2px solid #111827;
@@ -888,8 +886,6 @@
       <div class="card" data-content="post1-template" tabindex="0" role="button" aria-label="Does Your Problem Really Need AI?">Does Your Problem Really Need AI?</div>
       <div class="card" data-content="post2-template" tabindex="0" role="button" aria-label="Are LLMs Really Creative? Breaking Down the Myth">Are LLMs Really Creative? Breaking Down the Myth</div>
       <div class="card" data-content="post3-template" tabindex="0" role="button" aria-label="GPT-5 is not AGI. Here is why GPT-6 will not be either">GPT-5 is not AGI. Here is why GPT-6 will not be either</div>
-      <div class="card" tabindex="0" role="button" aria-label="Coming Soon">Coming Soon</div>
-      <div class="card" tabindex="0" role="button" aria-label="Coming Soon">Coming Soon</div>
       <div class="card" tabindex="0" role="button" aria-label="Coming Soon">Coming Soon</div>
       <div class="card" tabindex="0" role="button" aria-label="Coming Soon">Coming Soon</div>
       <div class="card" tabindex="0" role="button" aria-label="Coming Soon">Coming Soon</div>


### PR DESCRIPTION
## Summary
- Limit 2-minute Reads section to six cards, showing three posts and three coming soon placeholders.
- Rework card styles to keep main post cards on top while spreading all six evenly on hover.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a126bc44dc832490179bed351def78