### PR TITLE
Refactor 2-minute Reads section to responsive grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,6 +601,7 @@
             align-items: center;
             justify-content: center;
             position: relative;
+            overflow: hidden;
         }
         #reads-section .interactive-title {
             margin-bottom: 1rem;
@@ -624,19 +625,16 @@
 
 
         .card-stack {
-            position: relative;
+            display: grid;
             width: 100%;
-            max-width: 1200px;
-            height: 420px;
-            overflow: visible;
+            max-width: 1400px;
+            margin: 0 auto;
+            gap: 1.5rem;
+            overflow-x: hidden;
+            justify-content: center;
+            grid-template-columns: repeat(5, 1fr);
         }
         .card {
-            --hover-scale: 1;
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 260px;
-            height: 360px;
             color: #111827;
             display: flex;
             align-items: center;
@@ -649,23 +647,20 @@
             background: linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.1));
             backdrop-filter: blur(10px);
             box-shadow: 0 15px 30px rgba(0,0,0,0.2);
-            transition: transform 0.6s ease-in-out, box-shadow 0.3s ease;
-            transform: translate(-50%, -50%) rotate(var(--angle)) translate(var(--dx), var(--dy)) scale(var(--hover-scale));
-        }
-        .card-stack:hover .card,
-        .card-stack:focus-within .card {
-            transform: translate(-50%, -50%) translateX(calc(var(--pos) * 120%)) scale(var(--hover-scale));
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            width: 100%;
+            aspect-ratio: 13 / 18;
         }
         .card:hover {
-            --hover-scale: 1.05;
+            transform: scale(1.05);
             box-shadow: 0 20px 35px rgba(0,0,0,0.3);
         }
-        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); --angle: -8deg; --dx: -40px; --dy: -20px; --pos: -2.5; z-index: 6; }
-        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); --angle: 6deg; --dx: -10px; --dy: 30px; --pos: -1.5; z-index: 5; }
-        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); --angle: -4deg; --dx: 20px; --dy: -25px; --pos: -0.5; z-index: 4; }
-        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); --angle: 8deg; --dx: -30px; --dy: 15px; --pos: 0.5; z-index: 3; }
-        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); --angle: -6deg; --dx: 15px; --dy: 20px; --pos: 1.5; z-index: 2; }
-        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); --angle: 5deg; --dx: 35px; --dy: -15px; --pos: 2.5; z-index: 1; }
+        .card:nth-child(1) { background: linear-gradient(145deg, #ffdee9, #b5fffc); }
+        .card:nth-child(2) { background: linear-gradient(145deg, #d9a7c7, #fffcdc); }
+        .card:nth-child(3) { background: linear-gradient(145deg, #a1c4fd, #c2e9fb); }
+        .card:nth-child(4) { background: linear-gradient(145deg, #fbc2eb, #a6c1ee); }
+        .card:nth-child(5) { background: linear-gradient(145deg, #fdfcfb, #e2d1c3); }
+        .card:nth-child(6) { background: linear-gradient(145deg, #ffecd2, #fcb69f); }
 
         .card:focus {
             outline: 2px solid #111827;
@@ -673,29 +668,18 @@
         }
 
 
-        @media (max-width: 768px) {
+        @media (max-width: 1023px) {
+            .card-stack {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+        @media (max-width: 767px) {
             #reads-section {
                 padding: 3rem 0;
                 min-height: auto;
             }
             .card-stack {
-                height: auto;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                position: static;
-                gap: 1rem;
-            }
-            .card-stack:hover .card,
-            .card-stack:focus-within .card {
-                transform: scale(var(--hover-scale));
-            }
-            .card {
-                position: relative;
-                width: 80%;
-                max-width: 320px;
-                height: 240px;
-                transform: scale(var(--hover-scale));
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             }
         }
         .card-modal {


### PR DESCRIPTION
## Summary
- Replace overlapping card stack with a centered responsive grid for the 2-minute Reads section
- Preserve card hover effects and modal behavior while limiting layout to five columns on desktop, three on tablets, and one to two on mobile
- Hide overflow in the section to avoid scrollbars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12a7b4e3c83248e0a287b8c9838ad