### PR TITLE
[codex] Add Imagination article resources

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -66,9 +66,92 @@
             align-items: center;
             font-size: 1.1rem;
         }
+        .resource-title {
+            font-size: 1.1rem;
+            font-weight: 500;
+        }
         .resource.large {
             grid-row: span 2;
             grid-column: span 2;
+        }
+        .resource.articles {
+            align-items: stretch;
+            justify-content: flex-start;
+            gap: 1rem;
+            overflow: hidden;
+        }
+        .articles-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+        }
+        .article-count {
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 999px;
+            color: rgba(255,255,255,0.72);
+            font-size: 0.75rem;
+            padding: 0.2rem 0.55rem;
+            white-space: nowrap;
+        }
+        .featured-article,
+        .article-link {
+            color: inherit;
+            text-decoration: none;
+        }
+        .featured-article {
+            background: linear-gradient(145deg, rgba(77, 208, 225, 0.16), rgba(255, 193, 7, 0.08));
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 8px;
+            display: block;
+            padding: 1rem;
+        }
+        .article-label {
+            color: #79dce8;
+            font-size: 0.72rem;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            margin-bottom: 0.55rem;
+            text-transform: uppercase;
+        }
+        .article-title {
+            font-size: 1rem;
+            font-weight: 600;
+            line-height: 1.25;
+        }
+        .featured-article .article-title {
+            font-size: 1.22rem;
+        }
+        .article-definition {
+            color: rgba(255,255,255,0.72);
+            font-size: 0.84rem;
+            line-height: 1.45;
+            margin-top: 0.55rem;
+        }
+        .article-list {
+            display: grid;
+            gap: 0.55rem;
+        }
+        .article-link {
+            border: 1px solid rgba(255,255,255,0.11);
+            border-radius: 8px;
+            display: grid;
+            gap: 0.25rem;
+            padding: 0.75rem;
+            transition: background 0.2s ease, border-color 0.2s ease;
+        }
+        .article-link:hover,
+        .article-link:focus {
+            background: rgba(255,255,255,0.06);
+            border-color: rgba(121,220,232,0.45);
+            outline: none;
+        }
+        .article-link .article-title {
+            font-size: 0.92rem;
+        }
+        .article-link .article-definition {
+            font-size: 0.78rem;
+            margin-top: 0;
         }
         h1 {
             font-weight: 300;
@@ -95,6 +178,12 @@
             .container {
                 grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
                 grid-auto-rows: 150px;
+            }
+
+            .resource.articles {
+                grid-column: 1 / -1;
+                grid-row: span 4;
+                overflow: visible;
             }
         }
     </style>
@@ -130,15 +219,73 @@
                 { key: 'discussions', label: 'User Discussions' },
                 { key: 'polls', label: 'Interactive Polls' }
             ];
-            resources.sort(() => Math.random() - 0.5);
             resources.forEach((r, idx) => {
                 const block = document.createElement('div');
-                block.className = 'resource' + (idx % 2 === 0 ? ' large' : '');
+                const items = artefact.resources?.[r.key] || [];
+                block.className = 'resource' + (idx % 2 === 0 ? ' large' : '') + (r.key === 'articles' && items.length ? ' articles' : '');
                 const title = document.createElement('div');
+                title.className = 'resource-title';
                 title.textContent = r.label;
+
+                if (r.key === 'articles' && items.length) {
+                    const header = document.createElement('div');
+                    header.className = 'articles-header';
+
+                    const count = document.createElement('span');
+                    count.className = 'article-count';
+                    count.textContent = `${items.length} reads`;
+
+                    header.append(title, count);
+                    block.appendChild(header);
+                    block.appendChild(createFeaturedArticle(items[0]));
+
+                    const list = document.createElement('div');
+                    list.className = 'article-list';
+                    items.slice(1).forEach(article => list.appendChild(createArticleLink(article)));
+                    block.appendChild(list);
+                    grid.appendChild(block);
+                    return;
+                }
+
                 block.appendChild(title);
                 grid.appendChild(block);
             });
+        }
+
+        function createFeaturedArticle(article) {
+            const link = createArticleBase(article);
+            link.className = 'featured-article';
+
+            const label = document.createElement('div');
+            label.className = 'article-label';
+            label.textContent = 'Featured article';
+
+            link.prepend(label);
+            return link;
+        }
+
+        function createArticleLink(article) {
+            const link = createArticleBase(article);
+            link.className = 'article-link';
+            return link;
+        }
+
+        function createArticleBase(article) {
+            const link = document.createElement('a');
+            link.href = article.url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+
+            const title = document.createElement('div');
+            title.className = 'article-title';
+            title.textContent = article.title;
+
+            const definition = document.createElement('p');
+            definition.className = 'article-definition';
+            definition.textContent = article.definition;
+
+            link.append(title, definition);
+            return link;
         }
         loadArtefact();
     </script>

--- a/artefacts.json
+++ b/artefacts.json
@@ -2,7 +2,33 @@
   "artefacts": [
     {"name": "Moral Reasoning", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
     {"name": "Intuition", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
-    {"name": "Imagination", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
+    {"name": "Imagination", "resources": {"code": [], "videos": [], "articles": [
+      {
+        "title": "Applied imagination",
+        "definition": "A fundamental cognitive ignition system used to model, anticipate, and adapt to reality.",
+        "url": "https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2023.1275942/full"
+      },
+      {
+        "title": "Brain-consistent architecture for imagination",
+        "definition": "The intelligence-driven ability to generate internal mental patterns differing from immediate sensory inputs.",
+        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11368743/"
+      },
+      {
+        "title": "Rethinking Memory and Imagination",
+        "definition": "An active epistemological tool the brain uses to construct reality and fill gaps in conscious experience.",
+        "url": "https://dialnet.unirioja.es/descarga/articulo/10543518.pdf"
+      },
+      {
+        "title": "Imagination: Bridging the Intended, Delivered, and Received Curricula",
+        "definition": "The engaged mental act of seeing beyond immediate barriers to unveil hidden realities.",
+        "url": "https://scholarworks.bgsu.edu/cgi/viewcontent.cgi?article=1066&context=jche"
+      },
+      {
+        "title": "Creative Imagination in School Education During the First Childhood",
+        "definition": "A complex, omnipresent mental function driven by our biological and cultural necessity to adapt.",
+        "url": "https://pepsic.bvsalud.org/scielo.php?pid=S1413-85572025000100204&script=sci_arttext&tlng=en"
+      }
+    ], "discussions": [], "polls": []}},
     {"name": "Wisdom", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
     {"name": "Free Will", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
     {"name": "Self-Awareness", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},


### PR DESCRIPTION
## Summary

Adds the first populated artefact resource block for Imagination.

## Changes

- Adds five article records to `artefacts.json` for the Imagination artefact.
- Updates `artefact.html` so populated article resources render as a featured article plus supporting article links.
- Keeps empty resource types as placeholders and makes the resource order stable for review.

## Validation

- Parsed `artefacts.json` locally with `python -m json.tool`.
- Confirmed the Imagination artefact has five article entries.
- Served the page locally and confirmed the JSON endpoint returned HTTP 200.

Note: local `git push` was blocked by credentials for a different GitHub user, so the branch commits were written through the connected GitHub app.