### PR TITLE
[codex] Refine Imagination article block interactions

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -79,6 +79,7 @@
             justify-content: flex-start;
             gap: 1rem;
             overflow: hidden;
+            min-height: 0;
         }
         .articles-header {
             display: flex;
@@ -94,33 +95,14 @@
             padding: 0.2rem 0.55rem;
             white-space: nowrap;
         }
-        .featured-article,
         .article-link {
             color: inherit;
             text-decoration: none;
-        }
-        .featured-article {
-            background: linear-gradient(145deg, rgba(77, 208, 225, 0.16), rgba(255, 193, 7, 0.08));
-            border: 1px solid rgba(255,255,255,0.16);
-            border-radius: 8px;
-            display: block;
-            padding: 1rem;
-        }
-        .article-label {
-            color: #79dce8;
-            font-size: 0.72rem;
-            font-weight: 600;
-            letter-spacing: 0.08em;
-            margin-bottom: 0.55rem;
-            text-transform: uppercase;
         }
         .article-title {
             font-size: 1rem;
             font-weight: 600;
             line-height: 1.25;
-        }
-        .featured-article .article-title {
-            font-size: 1.22rem;
         }
         .article-definition {
             color: rgba(255,255,255,0.72);
@@ -131,6 +113,21 @@
         .article-list {
             display: grid;
             gap: 0.55rem;
+            overflow-y: auto;
+            padding-right: 0.35rem;
+            scrollbar-color: rgba(121,220,232,0.45) rgba(255,255,255,0.08);
+            scrollbar-width: thin;
+        }
+        .article-list::-webkit-scrollbar {
+            width: 8px;
+        }
+        .article-list::-webkit-scrollbar-track {
+            background: rgba(255,255,255,0.08);
+            border-radius: 999px;
+        }
+        .article-list::-webkit-scrollbar-thumb {
+            background: rgba(121,220,232,0.45);
+            border-radius: 999px;
         }
         .article-link {
             border: 1px solid rgba(255,255,255,0.11);
@@ -138,20 +135,32 @@
             display: grid;
             gap: 0.25rem;
             padding: 0.75rem;
-            transition: background 0.2s ease, border-color 0.2s ease;
+            transition: background 0.2s ease, border-color 0.2s ease, padding 0.2s ease;
         }
         .article-link:hover,
         .article-link:focus {
-            background: rgba(255,255,255,0.06);
+            background: linear-gradient(145deg, rgba(77, 208, 225, 0.16), rgba(255, 193, 7, 0.08));
             border-color: rgba(121,220,232,0.45);
             outline: none;
+            padding: 1rem;
         }
         .article-link .article-title {
             font-size: 0.92rem;
+            transition: font-size 0.2s ease;
+        }
+        .article-link:hover .article-title,
+        .article-link:focus .article-title {
+            font-size: 1.22rem;
         }
         .article-link .article-definition {
             font-size: 0.78rem;
             margin-top: 0;
+            transition: font-size 0.2s ease, margin-top 0.2s ease;
+        }
+        .article-link:hover .article-definition,
+        .article-link:focus .article-definition {
+            font-size: 0.84rem;
+            margin-top: 0.55rem;
         }
         h1 {
             font-weight: 300;
@@ -183,7 +192,6 @@
             .resource.articles {
                 grid-column: 1 / -1;
                 grid-row: span 4;
-                overflow: visible;
             }
         }
     </style>
@@ -237,11 +245,10 @@
 
                     header.append(title, count);
                     block.appendChild(header);
-                    block.appendChild(createFeaturedArticle(items[0]));
 
                     const list = document.createElement('div');
                     list.className = 'article-list';
-                    items.slice(1).forEach(article => list.appendChild(createArticleLink(article)));
+                    items.forEach(article => list.appendChild(createArticleLink(article)));
                     block.appendChild(list);
                     grid.appendChild(block);
                     return;
@@ -250,18 +257,6 @@
                 block.appendChild(title);
                 grid.appendChild(block);
             });
-        }
-
-        function createFeaturedArticle(article) {
-            const link = createArticleBase(article);
-            link.className = 'featured-article';
-
-            const label = document.createElement('div');
-            label.className = 'article-label';
-            label.textContent = 'Featured article';
-
-            link.prepend(label);
-            return link;
         }
 
         function createArticleLink(article) {


### PR DESCRIPTION
## Summary

Refines the Imagination article block after review.

## Changes

- Makes the Articles block internally scrollable so all five articles are reachable.
- Removes the permanently featured first article treatment.
- Makes each article expand to the larger highlighted treatment on hover or keyboard focus, then collapse when focus/hover moves away.

## Validation

- Parsed `artefacts.json` locally with `python -m json.tool`.

Context: PR #52 was merged before this follow-up interaction fix, so this PR contains the post-merge refinement.