### PR TITLE
[codex] Add video resources for populated artefacts

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -74,20 +74,27 @@
             grid-row: span 2;
             grid-column: span 2;
         }
-        .resource.articles {
+        .resource.articles,
+        .resource.videos {
             align-items: stretch;
             justify-content: flex-start;
             gap: 1rem;
             overflow: hidden;
             min-height: 0;
         }
-        .articles-header {
+        .resource.videos {
+            grid-row: span 2;
+            grid-column: span 2;
+        }
+        .articles-header,
+        .videos-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
             gap: 1rem;
         }
-        .article-count {
+        .article-count,
+        .video-count {
             border: 1px solid rgba(255,255,255,0.16);
             border-radius: 999px;
             color: rgba(255,255,255,0.72);
@@ -95,7 +102,8 @@
             padding: 0.2rem 0.55rem;
             white-space: nowrap;
         }
-        .article-link {
+        .article-link,
+        .video-card {
             color: inherit;
             text-decoration: none;
         }
@@ -162,6 +170,82 @@
             font-size: 0.84rem;
             margin-top: 0.55rem;
         }
+        .video-list {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.8rem;
+            min-height: 0;
+        }
+        .video-card {
+            border: 1px solid rgba(255,255,255,0.13);
+            border-radius: 8px;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            background: rgba(255,255,255,0.035);
+            min-width: 0;
+            transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+        }
+        .video-card:hover,
+        .video-card:focus {
+            background: rgba(255,255,255,0.065);
+            border-color: rgba(255,193,7,0.45);
+            outline: none;
+            transform: translateY(-2px);
+        }
+        .video-thumb {
+            aspect-ratio: 16 / 9;
+            background: linear-gradient(145deg, rgba(77,208,225,0.18), rgba(255,193,7,0.12));
+            background-position: center;
+            background-size: cover;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+            display: grid;
+            place-items: center;
+            position: relative;
+        }
+        .video-thumb::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(0,0,0,0.05), rgba(0,0,0,0.28));
+        }
+        .play-icon {
+            align-items: center;
+            background: rgba(0,0,0,0.68);
+            border: 1px solid rgba(255,255,255,0.28);
+            border-radius: 999px;
+            color: #fff;
+            display: flex;
+            height: 2.6rem;
+            justify-content: center;
+            position: relative;
+            width: 2.6rem;
+            z-index: 1;
+        }
+        .play-icon::before {
+            content: "";
+            border-bottom: 0.45rem solid transparent;
+            border-left: 0.7rem solid currentColor;
+            border-top: 0.45rem solid transparent;
+            margin-left: 0.18rem;
+        }
+        .video-info {
+            display: grid;
+            gap: 0.55rem;
+            padding: 0.85rem;
+        }
+        .video-title {
+            font-size: 0.94rem;
+            font-weight: 600;
+            line-height: 1.25;
+        }
+        .video-action {
+            color: #79dce8;
+            font-size: 0.78rem;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
         h1 {
             font-weight: 300;
             margin-bottom: 2rem;
@@ -189,9 +273,16 @@
                 grid-auto-rows: 150px;
             }
 
-            .resource.articles {
+            .resource.articles,
+            .resource.videos {
                 grid-column: 1 / -1;
                 grid-row: span 4;
+            }
+
+            .video-list {
+                grid-template-columns: 1fr;
+                overflow-y: auto;
+                padding-right: 0.35rem;
             }
         }
     </style>
@@ -230,10 +321,29 @@
             resources.forEach((r, idx) => {
                 const block = document.createElement('div');
                 const items = artefact.resources?.[r.key] || [];
-                block.className = 'resource' + (idx % 2 === 0 ? ' large' : '') + (r.key === 'articles' && items.length ? ' articles' : '');
+                block.className = 'resource' + (idx % 2 === 0 ? ' large' : '') + (r.key === 'articles' && items.length ? ' articles' : '') + (r.key === 'videos' && items.length ? ' videos' : '');
                 const title = document.createElement('div');
                 title.className = 'resource-title';
                 title.textContent = r.label;
+
+                if (r.key === 'videos' && items.length) {
+                    const header = document.createElement('div');
+                    header.className = 'videos-header';
+
+                    const count = document.createElement('span');
+                    count.className = 'video-count';
+                    count.textContent = `${items.length} videos`;
+
+                    header.append(title, count);
+                    block.appendChild(header);
+
+                    const list = document.createElement('div');
+                    list.className = 'video-list';
+                    items.forEach(video => list.appendChild(createVideoCard(video)));
+                    block.appendChild(list);
+                    grid.appendChild(block);
+                    return;
+                }
 
                 if (r.key === 'articles' && items.length) {
                     const header = document.createElement('div');
@@ -257,6 +367,52 @@
                 block.appendChild(title);
                 grid.appendChild(block);
             });
+        }
+
+        function createVideoCard(video) {
+            const link = document.createElement('a');
+            link.className = 'video-card';
+            link.href = video.url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+
+            const thumb = document.createElement('div');
+            thumb.className = 'video-thumb';
+            const videoId = getYouTubeId(video.url);
+            if (videoId) {
+                thumb.style.backgroundImage = `url(https://img.youtube.com/vi/${videoId}/hqdefault.jpg)`;
+            }
+
+            const play = document.createElement('span');
+            play.className = 'play-icon';
+            play.setAttribute('aria-hidden', 'true');
+            thumb.appendChild(play);
+
+            const info = document.createElement('div');
+            info.className = 'video-info';
+
+            const title = document.createElement('div');
+            title.className = 'video-title';
+            title.textContent = video.title;
+
+            const action = document.createElement('div');
+            action.className = 'video-action';
+            action.textContent = 'Watch';
+
+            info.append(title, action);
+            link.append(thumb, info);
+            return link;
+        }
+
+        function getYouTubeId(url) {
+            try {
+                const parsed = new URL(url);
+                if (parsed.hostname.includes('youtu.be')) return parsed.pathname.slice(1);
+                if (parsed.hostname.includes('youtube.com')) return parsed.searchParams.get('v');
+            } catch (error) {
+                return null;
+            }
+            return null;
         }
 
         function createArticleLink(article) {

--- a/artefacts.json
+++ b/artefacts.json
@@ -1,6 +1,15 @@
 {
   "artefacts": [
-    {"name": "Moral Reasoning", "resources": {"code": [], "videos": [], "articles": [
+    {"name": "Moral Reasoning", "resources": {"code": [], "videos": [
+      {
+        "title": "Kohlberg's Stages of Moral Development (Explained in 5 Mins) (2024)",
+        "url": "https://www.youtube.com/watch?v=74gBlWT8xKw"
+      },
+      {
+        "title": "The Heinz Dilemma (2020)",
+        "url": "https://www.youtube.com/watch?v=1_2qEOxSTsM"
+      }
+    ], "articles": [
       {
         "title": "The influence of moral reasoning on adolescent decision-making and stress responses during VR social-moral conflict",
         "definition": "The cognitive process of evaluating ethical rightness based on principles and outcomes, evolving from self-centered logic to universal principles.",
@@ -27,7 +36,16 @@
         "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12191677/"
       }
     ], "discussions": [], "polls": []}},
-    {"name": "Intuition", "resources": {"code": [], "videos": [], "articles": [
+    {"name": "Intuition", "resources": {"code": [], "videos": [
+      {
+        "title": "The Science of Intuition: How to Measure 'Gut Feelings' (2023)",
+        "url": "https://www.youtube.com/watch?v=H_WYbvkWOa8"
+      },
+      {
+        "title": "7 Signs You Have Good Intuition - Psych2Go (2020)",
+        "url": "https://www.youtube.com/watch?v=cUq8vWplkpQ"
+      }
+    ], "articles": [
       {
         "title": "Flow and intuition: a systems neuroscience comparison",
         "definition": "A rapid, nonconscious decision-making process rooted in automatic information processing.",
@@ -54,7 +72,16 @@
         "url": "https://www.frontiersin.org/journals/sociology/articles/10.3389/fsoc.2025.1560090/full"
       }
     ], "discussions": [], "polls": []}},
-    {"name": "Imagination", "resources": {"code": [], "videos": [], "articles": [
+    {"name": "Imagination", "resources": {"code": [], "videos": [
+      {
+        "title": "Active Imagination: Confrontation with the Unconscious (2022)",
+        "url": "https://www.youtube.com/watch?v=rRVlWEwmbfQ"
+      },
+      {
+        "title": "The Power of Imagination: How Your Mind Shapes Reality (2025)",
+        "url": "https://www.youtube.com/watch?v=ndfGFt6J0Wc"
+      }
+    ], "articles": [
       {
         "title": "Applied imagination",
         "definition": "A fundamental cognitive ignition system used to model, anticipate, and adapt to reality.",
@@ -85,7 +112,16 @@
     {"name": "Free Will", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
     {"name": "Self-Awareness", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
     {"name": "Spiritual Experience", "resources": {"code": [], "videos": [], "articles": [], "discussions": [], "polls": []}},
-    {"name": "Sense of Humor", "resources": {"code": [], "videos": [], "articles": [
+    {"name": "Sense of Humor", "resources": {"code": [], "videos": [
+      {
+        "title": "The Psychology of Humor: Why Are Things Funny? (2023)",
+        "url": "https://www.youtube.com/watch?v=SmL1sNnEKXc"
+      },
+      {
+        "title": "The Psychology of Humor, Laughter, and Comedians (2023)",
+        "url": "https://www.youtube.com/watch?v=8OKbtZ6ojtk"
+      }
+    ], "articles": [
       {
         "title": "\"Keep joking\": appreciation and production of humor in aging",
         "definition": "A high-level cognitive and social phenomenon based on incongruity-resolution that allows individuals to bond and cope with their environment.",
@@ -112,7 +148,16 @@
         "url": "https://www.researchgate.net/publication/390057510_The_Role_of_Humor_in_Coping_with_Adversity"
       }
     ], "discussions": [], "polls": []}},
-    {"name": "Abstract Existential Reflection", "resources": {"code": [], "videos": [], "articles": [
+    {"name": "Abstract Existential Reflection", "resources": {"code": [], "videos": [
+      {
+        "title": "The PHILOSOPHER Who Solved The MEANING of LIFE? (2024)",
+        "url": "https://www.youtube.com/watch?v=K_rBOGP37Mg"
+      },
+      {
+        "title": "Friedrich Nietzsche - How To Find Your Real Self (2020)",
+        "url": "https://www.youtube.com/watch?v=0OIZMGEQ298"
+      }
+    ], "articles": [
       {
         "title": "Existential thinking and religious/spiritual struggles in patients with major depressive disorder",
         "definition": "A cognitive process focused on fundamental questions about meaning, purpose, and mortality that provides a pathway to psychological healing, insight, and formulating new values.",


### PR DESCRIPTION
## Summary

Adds video resources and renders them as two-card video blocks.

## Changes

- Adds two YouTube video links each for `Imagination`, `Intuition`, `Sense of Humor`, `Moral Reasoning`, and `Abstract Existential Reflection`.
- Updates `artefact.html` so populated `videos` resources render as two equal thumbnail cards with play affordances and Watch labels.
- Uses YouTube thumbnail URLs derived from each video ID.
- Keeps existing article rendering unchanged.

## Validation

- Fetched the branch files after update and confirmed video data and renderer changes are present.

Note: local checkout is dirty from earlier branch work, so this PR was created directly from latest GitHub `main` through the connector.