### PR TITLE
[codex] Hide construction note on populated artefact pages

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -481,6 +481,11 @@
                 { key: 'discussions', label: 'User Discussions' },
                 { key: 'polls', label: 'Interactive Polls' }
             ];
+            const hasPopulatedResources = resources.some(({ key }) => (artefact.resources?.[key] || []).length > 0);
+            const constructionNote = document.getElementById('construction-note');
+            if (constructionNote && (hasPopulatedResources || poll)) {
+                constructionNote.hidden = true;
+            }
             resources.forEach((r, idx) => {
                 const block = document.createElement('div');
                 const items = artefact.resources?.[r.key] || [];


### PR DESCRIPTION
## Summary

Hides the `(resources under construction)` note for artefact pages that now have populated content.

## Changes

- Adds a conditional in `artefact.html` that hides `#construction-note` when the current artefact has populated resources or a poll.
- Keeps the note visible for artefacts that still have no populated resources.

## Validation

- Checked `main` after PR #58 was merged and confirmed this change was not included there, so this PR carries only the follow-up note-hiding fix.