### PR TITLE
[codex] Increase interactive poll block height

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -89,7 +89,7 @@
             grid-column: span 3;
         }
         .resource.polls {
-            grid-row: span 2;
+            grid-row: span 3;
             grid-column: span 4;
             gap: 1.35rem;
             padding: 2rem;
@@ -351,7 +351,7 @@
             border-radius: 8px;
             display: grid;
             gap: 1rem;
-            min-height: 0;
+            min-height: 22rem;
             padding: 1.15rem;
         }
         .poll-total {
@@ -389,7 +389,7 @@
             background: #ffc247;
         }
         .poll-chart {
-            min-height: 160px;
+            min-height: 220px;
             width: 100%;
         }
         .code-editor {
@@ -494,7 +494,7 @@
             }
 
             .resource.polls {
-                grid-row: span 6;
+                grid-row: span 8;
             }
 
             .video-list,


### PR DESCRIPTION
## Summary
- Increase the Interactive Polls block from 2 to 3 grid rows on desktop.
- Give the poll visual panel and chart a safer minimum height so the graph does not collapse after voting.
- Increase mobile poll height to preserve the stacked layout.

## Testing
- Opened `http://127.0.0.1:8005/artefact.html?artefact=Imagination` with Playwright CLI.
- Simulated selecting Yes and submitting.
- Verified the poll block measured `970x692`, the chart remained `220px` tall, and the submit/status area stayed visible inside the block.