### PR TITLE
[codex] Add FastAPI poll vote endpoint

### DIFF
--- a/artefact.html
+++ b/artefact.html
@@ -678,16 +678,44 @@
             visual.className = 'poll-visual';
             renderPollVisual(visual, poll, state);
 
-            submit.addEventListener('click', () => {
+            submit.addEventListener('click', async () => {
                 if (!selected) {
                     status.textContent = 'Choose Yes or No before submitting.';
                     return;
                 }
-                const nextState = { choice: selected, note: note.value.trim() };
-                localStorage.setItem(`poll:${poll.id}`, JSON.stringify(nextState));
-                status.textContent = 'Saved in this browser. Global GitHub-backed counts need a backend endpoint.';
-                renderPollVisual(visual, poll, nextState);
-                submit.textContent = 'Update local vote';
+                submit.disabled = true;
+                status.textContent = 'Saving vote...';
+                const previousChoice = state.synced ? state.choice : null;
+                const nextState = { choice: selected, note: note.value.trim(), synced: true };
+
+                try {
+                    const response = await fetch(`/api/polls/${encodeURIComponent(poll.id)}/vote`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            choice: selected,
+                            previous_choice: previousChoice,
+                            note: note.value.trim()
+                        })
+                    });
+                    if (!response.ok) throw new Error('Vote endpoint unavailable');
+                    const result = await response.json();
+                    Object.assign(poll, result.poll);
+                    Object.assign(state, nextState);
+                    localStorage.setItem(`poll:${poll.id}`, JSON.stringify(nextState));
+                    status.textContent = 'Saved to polls.json.';
+                    renderPollVisual(visual, poll, nextState);
+                    submit.textContent = 'Update vote';
+                } catch (error) {
+                    const fallbackState = { choice: selected, note: note.value.trim(), synced: false };
+                    Object.assign(state, fallbackState);
+                    localStorage.setItem(`poll:${poll.id}`, JSON.stringify(fallbackState));
+                    status.textContent = 'Saved in this browser. Start the FastAPI server to update polls.json.';
+                    renderPollVisual(visual, poll, fallbackState);
+                    submit.textContent = 'Update local vote';
+                } finally {
+                    submit.disabled = false;
+                }
             });
 
             actions.append(yesButton, noButton, note, submit, status);
@@ -718,8 +746,8 @@
 
         function getPollCounts(poll, state) {
             const counts = { yes: poll.votes?.yes || 0, no: poll.votes?.no || 0 };
-            if (state.choice === 'yes') counts.yes += 1;
-            if (state.choice === 'no') counts.no += 1;
+            if (!state.synced && state.choice === 'yes') counts.yes += 1;
+            if (!state.synced && state.choice === 'no') counts.no += 1;
             return counts;
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.14
+uvicorn[standard]==0.35.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Literal
+
+import json
+import tempfile
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+
+ROOT = Path(__file__).resolve().parent
+POLLS_PATH = ROOT / "polls.json"
+polls_lock = Lock()
+
+app = FastAPI(title="Not Some AI")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+class VoteRequest(BaseModel):
+    choice: Literal["yes", "no"]
+    previous_choice: Literal["yes", "no"] | None = None
+    note: str = Field(default="", max_length=1000)
+
+
+def read_polls() -> dict:
+    with POLLS_PATH.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_polls(data: dict) -> None:
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        delete=False,
+        dir=ROOT,
+        newline="\n",
+    ) as file:
+        json.dump(data, file, indent=2, ensure_ascii=False)
+        file.write("\n")
+        temp_path = Path(file.name)
+    temp_path.replace(POLLS_PATH)
+
+
+def find_poll(data: dict, poll_id: str) -> dict | None:
+    return next((poll for poll in data.get("polls", []) if poll.get("id") == poll_id), None)
+
+
+@app.get("/api/polls")
+def get_polls() -> dict:
+    return read_polls()
+
+
+@app.post("/api/polls/{poll_id}/vote")
+def submit_vote(poll_id: str, vote: VoteRequest) -> dict:
+    with polls_lock:
+        data = read_polls()
+        poll = find_poll(data, poll_id)
+        if poll is None:
+            raise HTTPException(status_code=404, detail="Poll not found")
+
+        votes = poll.setdefault("votes", {"yes": 0, "no": 0})
+        previous_choice = vote.previous_choice
+        if previous_choice and previous_choice != vote.choice:
+            votes[previous_choice] = max(0, int(votes.get(previous_choice, 0)) - 1)
+
+        if previous_choice != vote.choice:
+            votes[vote.choice] = int(votes.get(vote.choice, 0)) + 1
+
+        total = int(votes.get("yes", 0)) + int(votes.get("no", 0))
+        yes_pct = round((int(votes.get("yes", 0)) / total) * 100) if total else 0
+        no_pct = 100 - yes_pct if total else 0
+        poll.setdefault("history", []).append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "yes": yes_pct,
+                "no": no_pct,
+                "total": total,
+            }
+        )
+
+        note = vote.note.strip()
+        if note:
+            poll.setdefault("comments", []).append(
+                {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "choice": vote.choice,
+                    "note": note,
+                }
+            )
+
+        write_polls(data)
+        return {"poll": poll}
+
+
+app.mount("/", StaticFiles(directory=ROOT, html=True), name="static")


### PR DESCRIPTION
## Summary
- Add a FastAPI server that serves the static site and exposes poll APIs.
- Add `POST /api/polls/{poll_id}/vote` to update `polls.json` with vote counts, history entries, and optional notes/comments.
- Update the poll submit flow to call the API when available, while keeping localStorage fallback for static-only use.
- Add FastAPI/Uvicorn requirements.

## Testing
- `python -m py_compile server.py`
- `python -m json.tool polls.json`
- FastAPI TestClient write test confirmed votes/comments update `polls.json`, then restored the test vote.
- FastAPI TestClient smoke test confirmed `/api/polls` and `/artefact.html?artefact=Imagination` respond successfully.